### PR TITLE
refactor to get rid of DiffResults and handle dual numbers directly

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.7-
 ForwardDiff
-DiffResults
 StaticArrays
 FastSplat

--- a/src/MixedModeBroadcastAD.jl
+++ b/src/MixedModeBroadcastAD.jl
@@ -7,7 +7,6 @@ are derived from the prototypical AD package Capstan
 =#
 
 using ForwardDiff
-using DiffResults
 using StaticArrays
 using FastSplat
 

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -180,9 +180,8 @@ end
             ivs = @ncall $N SVector iv 
             ij_result = dual_eval_kernel(kernel, ivs)
             @inbounds output_value[I] = ForwardDiff.value(ij_result)
-            iderivs = view(input_derivs, I, :)
             for k in 1:$N
-                @inbounds iderivs[k] = ForwardDiff.partials(ij_result, k)
+                @inbounds input_derivs[I[1], I[2], k] = ForwardDiff.partials(ij_result, k)
             end
         end
         return

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -156,15 +156,6 @@ macro cuda_index(A)
     end)
 end
 
-@enum(CUfunc_cache, CU_FUNC_CACHE_PREFER_NONE   = 0x00,
-                    CU_FUNC_CACHE_PREFER_SHARED = 0x01,
-                    CU_FUNC_CACHE_PREFER_L1     = 0x02,
-                    CU_FUNC_CACHE_PREFER_EQUAL  = 0x03)
-
-function setcacheconfig(config::CUfunc_cache)
-    CUDAdrv.@apicall(:cuCtxSetCacheConfig, (CUfunc_cache,), config)
-end
-
 ### 
 @noinline function dual_eval_broadcast!(output_value::CuMatrix, input_derivs::CuArray{<:Any, 3},
                                         kernel, input_values::NTuple{N,<:CuMatrix}) where N

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -156,6 +156,15 @@ macro cuda_index(A)
     end)
 end
 
+@enum(CUfunc_cache, CU_FUNC_CACHE_PREFER_NONE   = 0x00,
+                    CU_FUNC_CACHE_PREFER_SHARED = 0x01,
+                    CU_FUNC_CACHE_PREFER_L1     = 0x02,
+                    CU_FUNC_CACHE_PREFER_EQUAL  = 0x03)
+
+function setcacheconfig(config::CUfunc_cache)
+    CUDAdrv.@apicall(:cuCtxSetCacheConfig, (CUfunc_cache,), config)
+end
+
 ### 
 @noinline function dual_eval_broadcast!(output_value::CuMatrix, input_derivs::CuArray{<:Any, 3},
                                         kernel, input_values::NTuple{N,<:CuMatrix}) where N

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -179,7 +179,7 @@ end
             @nexprs $N i->(iv_{i} = input_values[i][I])
             ivs = @ncall $N SVector iv 
             ij_result = dual_eval_kernel(kernel, ivs)
-            @inbounds output_value[i] = ForwardDiff.value(ij_result)
+            @inbounds output_value[I] = ForwardDiff.value(ij_result)
             iderivs = view(input_derivs, I, :)
             for k in 1:$N
                 @inbounds iderivs[k] = ForwardDiff.partials(ij_result, k)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -176,7 +176,7 @@ function backward!(i::BroadcastInstruction)
     f, args = first(i.input), i.input[2:end]
     output, input_derivs = i.output
     for i in 1:length(args)
-        args[i].deriv .+= input_derivs[:, :, i] .* deriv(output)
+        args[i].deriv .+= view(input_derivs, :, :, i) .* deriv(output)
     end
     return nothing
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -78,27 +78,34 @@ forward!(i::BroadcastInstruction{typeof(*)}) = invoke(forward!, Tuple{Instructio
 
 function forward!(i::BroadcastInstruction)
     output_variable = isa(i.output, Variable) ? i.output : first(i.output)
-    f, values = first(i.input), value.(i.input[2:end])
-    N, T = length(values), eltype(value(output_variable))
-    gradient_template = DiffResults.GradientResult(zeros(SVector{N,T}))
-    i.output = _forward_broadcast!(f, output_variable, values, gradient_template)
+    f, input_values = first(i.input), value.(i.input[2:end])
+    output_value = value(output_variable)
+    input_derivs = similar(output_value, length(output_value), length(input_values))
+    dual_eval_broadcast!(output_value, input_derivs, f, input_values)
+    i.output = (output_variable, input_derivs)
     return nothing
 end
 
-@noinline function _forward_broadcast!(f, output_variable, values, gradient_template)
-    # Use ForwardDiff to calculate `f(values[1][i], values[2][i], ...)` and
-    # `∇f(values[1][i], values[2][i], ...)` from a single elementwise application.
-    df = (y...) -> ForwardDiff.gradient!(gradient_template,
-                                         x -> @fastsplat(f(x...)),
-                                         @fastsplat(SVector(y...)))
-    df_results = df.(values...)
+# Use ForwardDiff to calculate `f(values[1][i], values[2][i], ...)` and
+# `∇f(values[1][i], values[2][i], ...)` from a single elementwise application. This
+# implementation is actually incomplete, but it doesn't matter for our performance
+# experiment. Specifically, it doesn't implement the proper reduction/expansion semantics
+# encountered when the arguments have different shapes. In other words, this implementation
+# only works when all broadcast arguments are arrays of the same shape (which is sufficient
+# for our benchmarking purposes).
+@noinline function dual_eval_broadcast!(output_value, input_derivs, f, input_values::NTuple{N,Any}) where {N}
+    for i in 1:length(output_value)
+        ith_result = dual_eval_kernel(f, getindex.(input_values, i))
+        output_value[i] = ForwardDiff.value(ith_result)
+        for j in 1:N
+            input_derivs[i, j] = ForwardDiff.partials(ith_result, j)
+        end
+    end
+end
 
-    # `df_results` is a `AbstractArray{DiffResults.DiffResult}`, i.e. each element of
-    # `df_results` corresponds to a primal value and intermediate gradient. We record
-    # both the values and the gradients back to the tape, which will be used in the
-    # backwards pass.
-    map!(DiffResults.value, output_variable.value, df_results)
-    return (output_variable, df_results)
+function dual_eval_kernel(f, inputs)
+    dual_inputs = ForwardDiff.dualize(Void, StaticArrays.SVector(inputs))
+    return @fastsplat(f(dual_inputs...))
 end
 
 ##################
@@ -159,20 +166,11 @@ end
 
 #=== mixed-mode broadcast optimization ===#
 
-# FIXME: this `@inbounds` is incorrectly placed, but it doesn't seem to have any impact
-#        when placed at the `getpartial` call site
-Base.@propagate_inbounds getpartial(x, i) = @inbounds DiffResults.derivative(x)[i]
-
-# This broadcast `backward!` implementation is actually incomplete, but it doesn't matter
-# for our performance experiment. Specifically, it doesn't implement the proper reduction
-# and expansion semantics encountered when the arguments have different shapes. In other
-# words, this implementation only works when all broadcast arguments are arrays of the same
-# shape (which is sufficient for our benchmarking purposes).
 function backward!(i::BroadcastInstruction)
     f, args = first(i.input), i.input[2:end]
-    output, df_results = i.output
+    output, input_derivs = i.output
     for i in 1:length(args)
-        args[i].deriv .+= getpartial.(df_results, i) .* deriv(output)
+        args[i].deriv .+= input_derivs[:, i] .* deriv(output)
     end
     return nothing
 end

--- a/test/perf/benchmark.jl
+++ b/test/perf/benchmark.jl
@@ -14,27 +14,27 @@ BenchmarkTools.DEFAULT_PARAMETERS.gcsample = true
 function benchmark(::Type{Array}, n, fused)
     inputs = Tuple(Array{Float32}((n,n)) for i in 1:10)
     if fused
-        @belapsed lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed lstm_update_c($inputs...)
     else
-        @belapsed unfused_lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed unfused_lstm_update_c($inputs...)
     end
 end
 
 function benchmark(::Type{CuArray}, n, fused)
     inputs = Tuple(CuArray{Float32}((n,n)) for i in 1:10)
     if fused
-        @belapsed cudanative_lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed cudanative_lstm_update_c($inputs...)
     else
-        @belapsed unfused_cudanative_lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed unfused_cudanative_lstm_update_c($inputs...)
     end
 end
 
 function benchmark_cuda(n, fused)
     inputs = Tuple(CuArray{Float32}((n,n)) for i in 1:10)
     if fused
-        @belapsed cuda_lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed cuda_lstm_update_c($inputs...)
     else
-        @belapsed unfused_cuda_lstm_update_c($inputs...) setup=(gc_enable(false)) teardown=(gc_enable(true))
+        @belapsed unfused_cuda_lstm_update_c($inputs...)
     end
 end
 

--- a/test/perf/benchmark_ad.jl
+++ b/test/perf/benchmark_ad.jl
@@ -1,3 +1,4 @@
+import MixedModeBroadcastAD
 using MixedModeBroadcastAD: record, forward!, backward!, CuArray
 using BenchmarkTools
 using CUDAnative
@@ -27,6 +28,7 @@ rows = Any[["environment", "size", "fused", "forwards", "backwards"]]
 for fused in [false, true], n in (2^i for i in 9:11), T in [Array, CuArray]
     tape = prepare(T, n, fused)
     benchmark(T, tape) # warm-up
+    MixedModeBroadcastAD.setcacheconfig(MixedModeBroadcastAD.CU_FUNC_CACHE_PREFER_L1)
     fwd, bwd = benchmark(T, tape)
     push!(rows, ["Julia $T", "$(n)x$(n)", fused, timedelta(fwd), timedelta(bwd)])
 end

--- a/test/perf/benchmark_ad.jl
+++ b/test/perf/benchmark_ad.jl
@@ -1,4 +1,3 @@
-import MixedModeBroadcastAD
 using MixedModeBroadcastAD: record, forward!, backward!, CuArray
 using BenchmarkTools
 using CUDAnative
@@ -28,7 +27,7 @@ rows = Any[["environment", "size", "fused", "forwards", "backwards"]]
 for fused in [false, true], n in (2^i for i in 9:11), T in [Array, CuArray]
     tape = prepare(T, n, fused)
     benchmark(T, tape) # warm-up
-    MixedModeBroadcastAD.setcacheconfig(MixedModeBroadcastAD.CU_FUNC_CACHE_PREFER_L1)
+    CUDAdrv.cache_config!(CUDAdrv.FUNC_CACHE_PREFER_L1)
     fwd, bwd = benchmark(T, tape)
     push!(rows, ["Julia $T", "$(n)x$(n)", fused, timedelta(fwd), timedelta(bwd)])
 end

--- a/test/perf/benchmark_ad.jl
+++ b/test/perf/benchmark_ad.jl
@@ -5,6 +5,12 @@ import CUDAdrv
 include("util.jl")
 include("../kernels.jl")
 
+# speed it up a little
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 1
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
+# make sure we collect CuArrays from previous iterations
+BenchmarkTools.DEFAULT_PARAMETERS.gcsample = true
+
 kernel(::Type{Array}, fused) = fused ? lstm_update_c : unfused_lstm_update_c
 kernel(::Type{CuArray}, fused) = fused ? cudanative_lstm_update_c : unfused_cudanative_lstm_update_c
 
@@ -15,20 +21,25 @@ function prepare(::Type{T}, n::Int, fused) where {T<:AbstractArray}
 end
 
 function benchmark(::Type{Array}, tape)
-    @elapsed(forward!(tape)), @elapsed(backward!(tape))
+    @belapsed(forward!($tape)), @belapsed(backward!($tape))
 end
 
 function benchmark(::Type{CuArray}, tape)
-    @elapsed((forward!(tape), CUDAdrv.synchronize())),
-    @elapsed((backward!(tape), CUDAdrv.synchronize()))
+    @belapsed((forward!($tape), CUDAdrv.synchronize())),
+    @belapsed((backward!($tape), CUDAdrv.synchronize()))
 end
 
 rows = Any[["environment", "size", "fused", "forwards", "backwards"]]
-for fused in [false, true], n in (2^i for i in 9:11), T in [Array, CuArray]
-    tape = prepare(T, n, fused)
-    benchmark(T, tape) # warm-up
-    CUDAdrv.cache_config!(CUDAdrv.FUNC_CACHE_PREFER_L1)
-    fwd, bwd = benchmark(T, tape)
-    push!(rows, ["Julia $T", "$(n)x$(n)", fused, timedelta(fwd), timedelta(bwd)])
+for fused in [false, true], n in (2^i for i in 9:11)
+    info("benchmarking fused=$fused size=$n")
+
+    # Julia arrays
+    for T in [Array, CuArray]
+        tape = prepare(T, n, fused)
+        benchmark(T, tape) # warm-up
+        # CUDAdrv.cache_config!(CUDAdrv.FUNC_CACHE_PREFER_L1)
+        fwd, bwd = benchmark(T, tape)
+        push!(rows, ["Julia $T", "$(n)x$(n)", fused, timedelta(fwd), timedelta(bwd)])
+    end
 end
 println(Markdown.MD(Markdown.Table(rows, [:r, :c, :c, :c, :c])))

--- a/test/perf/profile_ad.jl
+++ b/test/perf/profile_ad.jl
@@ -1,3 +1,4 @@
+import MixedModeBroadcastAD
 using MixedModeBroadcastAD: record, forward!, backward!, CuArray
 using CUDAnative
 import CUDAdrv
@@ -26,6 +27,7 @@ end
 tape = prepare()
 benchmark(tape)
 benchmark(tape) # re-run on existing tape triggers additional compilation
+MixedModeBroadcastAD.setcacheconfig(MixedModeBroadcastAD.CU_FUNC_CACHE_PREFER_L1)
 
 NVTX.@activate CUDAdrv.@profile begin
     ccall(:jl_dump_compiles, Void, (Ptr{Nothing},), STDERR.handle)


### PR DESCRIPTION
This way we can more easily play around with memory access patterns and don't have to think about the overhead the DiffResults API might be incurring