### PR TITLE
add naive downstream counter to variables, enabling load/add elision for certain backwards pass operations

### DIFF
--- a/src/ad/utilities.jl
+++ b/src/ad/utilities.jl
@@ -3,3 +3,6 @@ tuplize(x::Tuple) = x
 
 tuplemap(f, x) = f(x)
 tuplemap(f, x::Tuple) = map(f, x)
+
+tupleforeach(f, x) = f(x)
+tupleforeach(f, x::Tuple) = foreach(f, x)

--- a/src/ad/variables.jl
+++ b/src/ad/variables.jl
@@ -1,7 +1,8 @@
 mutable struct Variable{V}
     value::V
     deriv::V
-    Variable(value::V) where {V} = new{V}(value, initderiv(value))
+    downstreams::Int
+    Variable(value::V) where {V} = new{V}(value, initderiv(value), 0)
 end
 
 struct Record{V}
@@ -13,6 +14,7 @@ function Record(tape::Tape, f, input...)
     input_variables = map(i -> isa(i, Record) ? i.variable : i, input)
     output = tuplemap(Variable, f(map(value, input_variables)...))
     push!(tape, Instruction(f, input_variables, output))
+    tupleforeach(incrdownstreams!, input_variables)
     return tuplemap(x -> Record(tape, x), output)
 end
 
@@ -22,6 +24,21 @@ initderiv(x) = zero(x)
 initderiv!(x) = x
 initderiv!(v::Variable{<:AbstractArray}) = (fill!(v.deriv, 0); v)
 initderiv!(v::Variable{<:Number}) = (v.deriv = zero(v.deriv); v)
+
+macro propagate!(x, ∇)
+    return esc(quote
+        if isa($x, $Variable)
+            if $(x).downstreams > 1
+                $(x).deriv .+= $∇
+            else
+                $(x).deriv .= $∇
+            end
+        end
+    end)
+end
+
+incrdownstreams!(x) = x
+incrdownstreams!(v::Variable) = (v.downstreams += 1; v)
 
 seed!(v::Variable) = (v.deriv = one(v.deriv); nothing)
 seed!(r::Record) = seed!(r.variable)


### PR DESCRIPTION
This should get rid of an extra set of load/adds in the backwards pass without sacrificing correctness. 