### PR TITLE
DO NOT MERGE: linear broadcast

### DIFF
--- a/src/ad/primitives.jl
+++ b/src/ad/primitives.jl
@@ -221,7 +221,7 @@ end
     end
 
     quote
-        let I = @cuda_linear_index(output_duals)
+        let I = @cuda_index(output_duals)
             output_dual = @inbounds output_duals[I]
             output_deriv = @inbounds output_derivs[I]
             $body

--- a/src/gpu/CuArrays.jl
+++ b/src/gpu/CuArrays.jl
@@ -93,17 +93,10 @@ function cuda_dimensions(n::Integer)
     ceil(Int, n / threads), threads
 end
 
-macro cuda_linear_index(A)
+macro cuda_index(A)
     esc(quote
         i = (blockIdx().x-UInt32(1)) * blockDim().x + threadIdx().x
         i > length($A) && return
         i
-    end)
-end
-
-macro cuda_index(A)
-    esc(quote
-        i = @cuda_linear_index($A)
-        @inbounds CartesianIndices($A)[i]
     end)
 end

--- a/src/gpu/GPUArrays.jl
+++ b/src/gpu/GPUArrays.jl
@@ -35,15 +35,14 @@ end
 
 ### internal implementation (mostly copied from Base)
 
-# NOTE: we only implement a subset of broadcast, only supporting homogeneous container
-#       arguments (ie. equal shape and size)
-
-using Base.Broadcast: broadcast_indices, check_broadcast_indices, map_newindexer
+using Base.Broadcast: broadcast_indices
 
 # This indirection allows size-dependent implementations.
 @inline function _broadcast!(f, C::GPUArrays, A, Bs::Vararg{Any,N}) where N
-    shape = broadcast_indices(C)
-    @boundscheck check_broadcast_indices(shape, A, Bs...)
+    # we only implement a very limited subset of broadcast
+    @assert all(X->isa(X, GPUArrays), [A, Bs...])
+    @assert all(X->size(X)==size(C), [A, Bs...])
+
     blk, thr = cuda_dimensions(C)
     @cuda blocks=blk threads=thr _broadcast_kernel!(f, C, A, Bs, Val(N))
     return C

--- a/src/gpu/GPUArrays.jl
+++ b/src/gpu/GPUArrays.jl
@@ -42,6 +42,8 @@ using Base.Broadcast: broadcast_indices
     # we only implement a very limited subset of broadcast
     @assert all(X->isa(X, GPUArrays), [A, Bs...])
     @assert all(X->size(X)==size(C), [A, Bs...])
+    # TODO: at least allow indexing 1D N-length containers when the output container is
+    #       2D N by N (the boolean arrays in our demo is such an 1D container)
 
     blk, thr = cuda_dimensions(C)
     @cuda blocks=blk threads=thr _broadcast_kernel!(f, C, A, Bs, Val(N))
@@ -76,7 +78,7 @@ end
 
 function Base.fill!(xs::GPUArrays, x)
     function _fill_kernel!(xs::GPUDeviceArrays, x)
-        I = @cuda_linear_index xs
+        I = @cuda_index xs
         @inbounds xs[I] = x
         return
     end

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -97,7 +97,7 @@ function getkernel(kind::Symbol, soa::Bool = true, dims::Int = 2048)
         kernel = gpu_hmlstm_update_c
         A = CuArray
     end
-    bools = (convert(A, rand(Bool, dims)), convert(A, rand(Bool, dims)))
+    bools = (convert(A, rand(Bool, dims, dims)), convert(A, rand(Bool, dims, dims)))
     n = 4
     if soa
         inputs = Tuple(tosoa(A{Float32,2}, rand(Float32, dims, dims)) for _ in 1:n)


### PR DESCRIPTION
~~Bad news: I made the forwards pass faster again.~~ Apparently, the code bloat caused by the broadcast infrastructure selecting a valid index (ie. CartesianIndex, broadcast_getindex, newindex, etc) _does_ effect the performance of the forwards pass. I had expected it not to, because trying that out with the backwards pass did not yield any speedup (https://github.com/jrevels/MixedModeBroadcastAD.jl/commit/a2b60706b36db2330977fc7664a8902dba06d914).

Measurements on master:
```
==19238==       Range "backward pass"
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
          Range:  100.00%  558.43ms      1024  545.34us  539.91us  695.33us  backward pass
 GPU activities:  100.00%  439.15ms      1024  428.85us  426.88us  430.56us  ptxcall__backprop_partial_broadcast__5
      API calls:  100.00%  15.039ms      1024  14.686us  13.845us  21.908us  cuLaunchKernel

==19238==       Range "forward pass"
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
          Range:  100.00%  837.71ms      1024  818.08us  601.73us  208.15ms  forward pass
 GPU activities:   91.50%  508.29ms      1024  496.38us  493.02us  502.04us  ptxcall__broadcast__3
                    8.50%  47.233ms      1024  46.126us  45.503us  48.607us  ptxcall__broadcast__4
      API calls:  100.00%  234.73ms      2048  114.61us  10.687us  207.50ms  cuLaunchKernel
```

This PR:
```
==19552==       Range "forward pass"
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
          Range:  100.00%  549.84ms      1024  536.96us  328.71us  202.01ms  forward pass
 GPU activities:   89.85%  253.82ms      1024  247.87us  247.10us  251.77us  ptxcall__broadcast__3
                   10.15%  28.684ms      1024  28.011us  27.583us  30.816us  ptxcall__broadcast__4
      API calls:  100.00%  226.26ms      2048  110.48us  9.4660us  201.63ms  cuLaunchKernel
```

So this cuts the forwards time almost in half. Which in turn exposes again how our mental model about the pass complexity is off.

This PR is just a POC, it would be nice (and much more efficient) if somebody with more broadcast-fu could figure a way to dispatch on this property. One tricky part is that the arguments are not homogeneous, as the function argument is still present (hence the `linear_index` function).