### PR TITLE
disable fast-math for XLA

### DIFF
--- a/test/runbenchmarks.py
+++ b/test/runbenchmarks.py
@@ -1,3 +1,7 @@
+import os
+os.environ.setdefault('TF_XLA_FLAGS', '')
+os.environ['TF_XLA_FLAGS'] += ' --xla_enable_fast_math=false'
+
 import argparse
 import tensorflow as tf
 import kernels

--- a/test/runprofile.py
+++ b/test/runprofile.py
@@ -1,3 +1,7 @@
+import os
+os.environ.setdefault('TF_XLA_FLAGS', '')
+os.environ['TF_XLA_FLAGS'] += ' --xla_enable_fast_math=false'
+
 import argparse
 import tensorflow as tf
 from tensorflow.python.client import timeline


### PR DESCRIPTION
Since Julia doesn't use fast-math per default.

- [x] Need to verify that this is sufficient. 