### PR TITLE
Adapt to broadcast changes for 0.7

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -1,6 +1,6 @@
 {
     "refs": {
-        "julia":            "f4349c14dcf08e4b4e6e2806c5f389bcabbd0cf2",
+        "julia":            "74af87841b8652e80de10ae4a101de2d6a2f4434",
         "LLVM":             "v0.9.6",
         "CUDAapi":          "v0.4.2",
         "CUDAdrv":          "v0.8.3",

--- a/src/MixedModeBroadcastAD.jl
+++ b/src/MixedModeBroadcastAD.jl
@@ -160,9 +160,9 @@ function broadcast_gradients!(kernel::K,
     @assert is_valid_input_and_derivs(wrtinputs, derivs)
     dual_kernel = DualKernel(kernel, typeof(wrtinputs))
     inputs = unwrt.(wrtinputs)
-    shape = Broadcast.combine_indices(inputs...)
-    @boundscheck Broadcast.check_broadcast_indices(shape, inputs...)
-    keep_bools, default_indices = Broadcast.map_newindexer(shape, first(inputs), Base.tail(inputs))
+    shape = Broadcast.combine_axes(inputs...)
+    @boundscheck Broadcast.check_broadcast_axes(shape, inputs...)
+    keep_bools, default_indices = zip(map(Broadcast.newindexer, inputs)...)
     _dual_broadcast_kernel!(dual_kernel, inputs, derivs, keep_bools, default_indices, shape)
     return nothing
 end


### PR DESCRIPTION
Adapt to upstream changes to the broadcast infrastructure. The `broadcast!` changes are nice and straightforward.
`broadcast_gradients!` is more involved and it currently seems to be allocating on the GPU.